### PR TITLE
Fix weather one call from remote device

### DIFF
--- a/ovos_local_backend/__main__.py
+++ b/ovos_local_backend/__main__.py
@@ -1,7 +1,6 @@
 from ovos_local_backend.backend import start_backend
 from ovos_local_backend.configuration import CONFIGURATION
 
-
 def main():
     import argparse
 

--- a/ovos_local_backend/backend/external_apis.py
+++ b/ovos_local_backend/backend/external_apis.py
@@ -41,7 +41,6 @@ def _get_latlon():
 def get_services_routes(app):
 
     apis = ExternalApiManager()
-
     @app.route("/" + API_VERSION + '/geolocation', methods=['GET'])
     @noindex
     @check_selene_pairing

--- a/ovos_local_backend/utils/__init__.py
+++ b/ovos_local_backend/utils/__init__.py
@@ -14,6 +14,7 @@ import json
 import random
 
 from flask import make_response
+from ovos_utils.log import LOG
 from ovos_utils.ovos_service_api import OvosWolframAlpha, OvosWeather
 from ovos_backend_client.api import GeolocationApi, WolframAlphaApi, OpenWeatherMapApi
 
@@ -69,7 +70,11 @@ class ExternalApiManager:
 
         self.ovos_wolfram = OvosWolframAlpha()
         self.ovos_owm = OvosWeather()
-
+        if not self.ovos_owm.uuid:
+            try:
+                self.ovos_owm.api.register_device()
+            except Exception as e:
+                LOG.debug(f"Error registering device {e}")
         self.geo = Geocoder()
 
         self.selene_owm = None

--- a/ovos_local_backend/utils/__init__.py
+++ b/ovos_local_backend/utils/__init__.py
@@ -60,7 +60,7 @@ def dict_to_camel_case(data):
 
 
 class ExternalApiManager:
-    def __int__(self):
+    def __init__(self):
         self.config = CONFIGURATION.get("microservices", {})
         self.units = CONFIGURATION["system_unit"]
 
@@ -221,7 +221,7 @@ class ExternalApiManager:
 
 
 class LocalWeather:
-    def __int__(self, key):
+    def __init__(self, key):
         self.key = key
 
     def current(self, lat, lon, units, lang):
@@ -266,7 +266,7 @@ class LocalWeather:
 
 
 class LocalWolfram:
-    def __int__(self, key):
+    def __init__(self, key):
         self.key = key
 
     def spoken(self, query, units):

--- a/ovos_local_backend/utils/__init__.py
+++ b/ovos_local_backend/utils/__init__.py
@@ -183,7 +183,7 @@ class ExternalApiManager:
             q = {"input": query, "units": units, "output": "xml"}
             return self._wolfram.get_wolfram_full(q)
 
-    def own_current(self, lat, lon, units, lang="en-us"):
+    def owm_current(self, lat, lon, units, lang="en-us"):
         if isinstance(self._owm, LocalWeather):  # local
             return self._owm.current(lat, lon, units, lang)
         if isinstance(self._owm, OvosWeather):  # ovos
@@ -201,7 +201,7 @@ class ExternalApiManager:
         if isinstance(self._owm, OpenWeatherMapApi):  # selene
             return self._owm.get_weather((lat, lon), lang, units)
 
-    def own_hourly(self, lat, lon, units, lang="en-us"):
+    def owm_hourly(self, lat, lon, units, lang="en-us"):
         if isinstance(self._owm, LocalWeather):  # local
             return self._owm.hourly(lat, lon, units, lang)
         if isinstance(self._owm, OvosWeather):  # ovos
@@ -210,7 +210,7 @@ class ExternalApiManager:
         if isinstance(self._owm, OpenWeatherMapApi):  # selene
             return self._owm.get_hourly((lat, lon), lang, units)
 
-    def own_daily(self, lat, lon, units, lang="en-us"):
+    def owm_daily(self, lat, lon, units, lang="en-us"):
         if isinstance(self._owm, LocalWeather):  # local
             return self._owm.daily(lat, lon, units, lang)
         if isinstance(self._owm, OvosWeather):  # ovos


### PR DESCRIPTION
With the default install, when a device would request the weather from the server, I would get this error.

```
[2022-10-15 10:41:45,337] ERROR in app: Exception on /v1/owm/onecall [GET]
Traceback (most recent call last):
  File "/home/jbrodie/.local/lib/python3.10/site-packages/flask/app.py", line 2525, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/jbrodie/.local/lib/python3.10/site-packages/flask/app.py", line 1822, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/jbrodie/.local/lib/python3.10/site-packages/flask/app.py", line 1820, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/jbrodie/.local/lib/python3.10/site-packages/flask/app.py", line 1796, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/home/jbrodie/.local/lib/python3.10/site-packages/ovos_local_backend/backend/decorators.py", line 99, in decorated_function
    resp = make_response(f(*args, **kwargs))
  File "/home/jbrodie/.local/lib/python3.10/site-packages/ovos_local_backend/backend/decorators.py", line 54, in decorated
    return f(*args, **kwargs)
  File "/home/jbrodie/.local/lib/python3.10/site-packages/ovos_local_backend/backend/decorators.py", line 72, in decorated
    return f(*args, **kwargs)
  File "/home/jbrodie/.local/lib/python3.10/site-packages/ovos_local_backend/backend/external_apis.py", line 136, in owm_onecall
    data = apis.owm_onecall(lat, lon, units, lang)
  File "/home/jbrodie/.local/lib/python3.10/site-packages/ovos_local_backend/utils/__init__.py", line 196, in owm_onecall
    if isinstance(self._owm, LocalWeather):  # local
  File "/home/jbrodie/.local/lib/python3.10/site-packages/ovos_local_backend/utils/__init__.py", line 87, in _owm
    if self.config.get("weather_provider") == "local":
AttributeError: 'ExternalApiManager' object has no attribute 'config'
```
After a couple of fixes of typos, I got it to go further and then got this error.
```
[2022-10-15 10:16:42,707] ERROR in app: Exception on /v1/owm/onecall [GET]
Traceback (most recent call last):
  File "/home/jbrodie/.local/lib/python3.10/site-packages/requests/models.py", line 971, in json
    return complexjson.loads(self.text, **kwargs)
  File "/usr/lib/python3/dist-packages/simplejson/__init__.py", line 525, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3/dist-packages/simplejson/decoder.py", line 370, in decode
    obj, end = self.raw_decode(s)
  File "/usr/lib/python3/dist-packages/simplejson/decoder.py", line 400, in raw_decode
    return self.scan_once(s, idx=_w(s, idx).end())
simplejson.errors.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/jbrodie/.local/lib/python3.10/site-packages/flask/app.py", line 2525, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/jbrodie/.local/lib/python3.10/site-packages/flask/app.py", line 1822, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/jbrodie/.local/lib/python3.10/site-packages/flask/app.py", line 1820, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/jbrodie/.local/lib/python3.10/site-packages/flask/app.py", line 1796, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/home/jbrodie/.local/lib/python3.10/site-packages/ovos_local_backend/backend/decorators.py", line 99, in decorated_function
    resp = make_response(f(*args, **kwargs))
  File "/home/jbrodie/.local/lib/python3.10/site-packages/ovos_local_backend/backend/decorators.py", line 54, in decorated
    return f(*args, **kwargs)
  File "/home/jbrodie/.local/lib/python3.10/site-packages/ovos_local_backend/backend/decorators.py", line 72, in decorated
    return f(*args, **kwargs)
  File "/home/jbrodie/.local/lib/python3.10/site-packages/ovos_local_backend/backend/external_apis.py", line 135, in owm_onecall
    data = apis.owm_onecall(lat, lon, units, lang)
  File "/home/jbrodie/.local/lib/python3.10/site-packages/ovos_local_backend/utils/__init__.py", line 200, in owm_onecall
    return self._owm.get_weather_onecall(params)
  File "/home/jbrodie/.local/lib/python3.10/site-packages/ovos_utils/ovos_service_api.py", line 91, in get_weather_onecall
    return r.json()
  File "/home/jbrodie/.local/lib/python3.10/site-packages/requests/models.py", line 975, in json
    raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```
What was happening, is the `ovos_api_uuid.json` file was not being created if it was non-existent.
This PR fixes the typos, and also checks for the file and creates it if needed.
