### PR TITLE
Fix/selene UUID

### DIFF
--- a/ovos_local_backend/database/settings.py
+++ b/ovos_local_backend/database/settings.py
@@ -51,7 +51,12 @@ class SkillSettings:
                             else:
                                 val = False
                         elif t == "number":
-                            val = float(val)
+                            if val == "False":
+                                val = 0
+                            elif val == "True":
+                                val = 1
+                            else:
+                                val = float(val)
                         elif val.lower() in ["none", "null", "nan"]:
                             val = None
                         elif val == "[]":
@@ -166,9 +171,19 @@ class DeviceSettings:
         # NOTE - selene returns the full listener config
         # this SHOULD NOT be done, since backend has no clue of hardware downstream
         # we return only wake word config
-        ww_cfg = {self.default_ww: self.default_ww_cfg}
+        if self.default_ww and self.default_ww_cfg:
+            ww_cfg = {self.default_ww: self.default_ww_cfg}
+            listener = {"wakeWord": self.default_ww.replace(" ", "_")}
+        else:
+            ww_cfg = {}
+            listener = {}
+
         tts_config = dict(self.default_tts_cfg)
-        tts = tts_config.pop("module")
+        if "module" in tts_config:
+            tts = tts_config.pop("module")
+            tts_settings =  {"module": tts, tts: tts_config}
+        else:
+            tts_settings = {}
         return {
             "dateFormat": self.date_format,
             "optIn": self.opt_in,
@@ -177,9 +192,9 @@ class DeviceSettings:
             "uuid": self.uuid,
             "lang": self.lang,
             "location": self.location,
-            "listenerSetting": {"wakeWord": self.default_ww.replace(" ", "_")},
+            "listenerSetting": listener,
             "hotwordsSetting": ww_cfg,  # not present in selene, parsed correctly by core
-            'ttsSettings': {"module": tts, tts: tts_config}
+            'ttsSettings': tts_settings
         }
 
     def serialize(self):

--- a/ovos_local_backend/utils/selene.py
+++ b/ovos_local_backend/utils/selene.py
@@ -11,7 +11,7 @@ from ovos_local_backend.configuration import CONFIGURATION, BACKEND_IDENTITY
 from ovos_local_backend.database.settings import SkillSettings, SharedSettingsDatabase, DeviceDatabase
 
 _selene_pairing_data = None
-_selene_uuid = uuid4()
+_selene_uuid = str(uuid4())
 _selene_cfg = CONFIGURATION.get("selene") or {}
 
 _ident_file = _selene_cfg.get("identity_file", "")
@@ -219,7 +219,7 @@ def get_selene_pairing_data():
     global _selene_pairing_data, _selene_uuid
     if not _selene_pairing_data:
         try:
-            _selene_uuid = uuid4()
+            _selene_uuid = str(uuid4())
             _selene_pairing_data = _device_api.get_code(_selene_uuid)
         except:
             LOG.exception("Failed to get selene pairing data")


### PR DESCRIPTION
fix selene pairing not being a proper string

handle cases with missing tts/ww, this is common but cause issues when downloading remote config

fix for bad settingsmeta files which send booleans as numbers