### PR TITLE
Fix/table population

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:latest
 
 RUN apt-get update && \
-  apt-get install -y git python3 python3-dev python3-pip curl build-essential libffi-dev python3-numpy rustc
+  apt-get install -y git python3 python3-dev python3-pip curl build-essential libffi-dev python3-numpy rustc flac libmysqlclient-dev
 
 RUN pip3 install SpeechRecognition==3.8.1
 

--- a/ovos_local_backend/backend/admin.py
+++ b/ovos_local_backend/backend/admin.py
@@ -19,7 +19,7 @@ from ovos_local_backend.backend.decorators import noindex, requires_admin
 from ovos_local_backend.database import add_device, update_device
 from ovos_local_backend.utils import generate_code
 from ovos_local_backend.utils import nice_json
-from ovos_local_backend.utils.geolocate import get_request_location
+from ovos_local_backend.utils.geolocate import Location
 
 
 def get_admin_routes(app):
@@ -30,8 +30,7 @@ def get_admin_routes(app):
         code = generate_code()
         token = f"{code}:{uuid}"
         # add device to db
-        location = get_request_location()
-        add_device(uuid, token, location=location)
+        add_device(uuid, token)
 
         device = {"uuid": uuid,
                   "expires_at": time.time() + 99999999999999,
@@ -50,7 +49,7 @@ def get_admin_routes(app):
     @requires_admin
     @noindex
     def set_location(uuid):
-        device_data = update_device(uuid, location=request.json)
+        device_data = update_device(uuid, **Location(request.json).serialize)
         return nice_json(device_data)
 
     @app.route("/" + API_VERSION + "/admin/<uuid>/prefs", methods=['PUT'])

--- a/ovos_local_backend/backend/decorators.py
+++ b/ovos_local_backend/backend/decorators.py
@@ -13,13 +13,14 @@
 from functools import wraps
 from flask import make_response, request, Response
 from ovos_local_backend.configuration import CONFIGURATION
-from ovos_local_backend.database import get_device
 from ovos_local_backend.utils.selene import attempt_selene_pairing, requires_selene_pairing
 from ovos_backend_client.pairing import is_paired
 
 
 def check_auth(uid, token):
     """This function is called to check if a access token is valid."""
+    from ovos_local_backend.database import get_device
+
     device = get_device(uid)
     if device and device.token == token:
         return True
@@ -29,6 +30,8 @@ def check_auth(uid, token):
 def requires_opt_in(f):
     @wraps(f)
     def decorated(*args, **kwargs):
+        from ovos_local_backend.database import get_device
+
         auth = request.headers.get('Authorization', '').replace("Bearer ", "")
         uuid = kwargs.get("uuid") or auth.split(":")[-1]  # this split is only valid here, not selene
         device = get_device(uuid)

--- a/ovos_local_backend/backend/precise.py
+++ b/ovos_local_backend/backend/precise.py
@@ -1,10 +1,10 @@
 from flask import request
 
+from ovos_local_backend.backend import API_VERSION
 from ovos_local_backend.backend.decorators import noindex, requires_auth, check_selene_pairing
 from ovos_local_backend.configuration import CONFIGURATION
 from ovos_local_backend.database import save_ww_recording
 from ovos_local_backend.utils.selene import upload_ww
-
 
 def get_precise_routes(app):
     @app.route('/precise/upload', methods=['POST'])
@@ -12,36 +12,39 @@ def get_precise_routes(app):
     @check_selene_pairing
     @requires_auth
     def precise_upload():
+        success = uploaded = False
         if CONFIGURATION["record_wakewords"]:
             auth = request.headers.get('Authorization', '').replace("Bearer ", "")
             uuid = auth.split(":")[-1]  # this split is only valid here, not selene
-            save_ww_recording(uuid, request.files)
+            success = save_ww_recording(uuid, request.files)
 
-        uploaded = False
         selene_cfg = CONFIGURATION.get("selene") or {}
         if selene_cfg.get("upload_wakewords"):
             # contribute to mycroft open dataset
             uploaded = upload_ww(request.files)
 
-        return {"success": True,
+        return {"success": success,
                 "sent_to_mycroft": uploaded,
                 "saved": CONFIGURATION["record_wakewords"]}
 
-    @app.route('/device/<uuid>/wake-word-file', methods=['POST'])
+    @app.route(f'/{API_VERSION}/device/<uuid>/wake-word-file', methods=['POST'])
     @noindex
     @check_selene_pairing
     @requires_auth
     def precise_upload_v2(uuid):
+        success = uploaded = False
+        if 'audio' not in request.files:
+            return "No Audio to upload", 400
+        
         if CONFIGURATION["record_wakewords"]:
-            save_ww_recording(uuid, request.files)
+            success = save_ww_recording(uuid, request.files)
 
-        uploaded = False
         selene_cfg = CONFIGURATION.get("selene") or {}
         if selene_cfg.get("upload_wakewords"):
             # contribute to mycroft open dataset
             uploaded = upload_ww(request.files)
-
-        return {"success": True,
+ 
+        return {"success": success,
                 "sent_to_mycroft": uploaded,
                 "saved": CONFIGURATION["record_wakewords"]}
 

--- a/ovos_local_backend/configuration.py
+++ b/ovos_local_backend/configuration.py
@@ -35,28 +35,15 @@ DEFAULT_CONFIG = {
     "admin_key": "",  # To enable simply set this string to something
     "skip_auth": False,  # you almost certainly do not want this, only for atypical use cases such as ovos-qubes
     "default_location": {
-        "city": {
-            "code": "Lawrence",
-            "name": "Lawrence",
-            "state": {
-                "code": "KS",
-                "name": "Kansas",
-                "country": {
-                    "code": "US",
-                    "name": "United States"
-                }
-            }
-        },
-        "coordinate": {
-            "latitude": 38.971669,
-            "longitude": -95.23525
-        },
-        "timezone": {
-            "code": "America/Chicago",
-            "name": "Central Standard Time",
-            "dstOffset": 3600000,
-            "offset": -21600000
-        }
+        "city": "Lawrence",
+        "address": "Lawrence",
+        "state": "Kansas",
+        "region": "Kansas",
+        "country": "United States",
+        "country_code": "US",
+        "latitude": 38.971669,
+        "longitude": -95.23525,
+        "tz_short": "CST",
     },
     "default_ww": "hey_mycroft",  # needs to be present below
     "ww_configs": {  # these can be exposed in a web UI for selection

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -11,3 +11,5 @@ requests_cache
 ovos-backend-client~=0.0, >=0.0.6a10
 oauthlib~=3.0
 Flask-SQLAlchemy
+Flask-MySQLdb
+sqlalchemy-json


### PR DESCRIPTION
Adds:

- mysql requirements (if used outside docker `libmysqlclient-dev` is needed)
- json field (package sqlalchemy-json)
- possibility to update fields individually (based on kwargs)
- streamlined database helper: `add_*`, `get_*`, `update_*`

Fixes:
- table definitions
- v2 precise endpoint

changes:
- location configuration (Location().old_conf is temporary and produces the old json structure)


Tested for all tables (device / metric / ww resp. utterance upload / ww resp. voice definitions / skill settings)
(_note: ww upload will only work if `Content-Type` is popped off the headers_)
to check: everything coming from or sent to mycroft selene