### PR TITLE
updated requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -10,3 +10,5 @@ requests_cache
 oauthlib~=3.0
 Flask-SQLAlchemy
 sqlalchemy-json
+ovos-config>=0.0.10
+


### PR DESCRIPTION
with `ovos-config==0.0.8` I would get this error
```
Traceback (most recent call last):
  File "/home/jbrodie/.local/bin/ovos-local-backend", line 5, in <module>
    from ovos_local_backend.__main__ import main
  File "/home/jbrodie/.local/lib/python3.10/site-packages/ovos_local_backend/__init__.py", line 3, in <module>
    from ovos_config.utils import init_module_config
ImportError: cannot import name 'init_module_config' from 'ovos_config.utils' (/home/jbrodie/.local/lib/python3.10/site-packages/ovos_config/utils.py)
```
Updating to `ovos-config==0.0.10` fixes this