### PR TITLE
Readme: Correct path for config

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You can use this backend as a STT server proxy via [ovos-stt-plugin-server](http
 
 ## Configuration
 
-configure backend by editing/creating ```~/.config/mycroft/ovos_backend.conf```
+configure backend by editing/creating ```~/.config/ovos_backend/ovos_backend.conf```
 
 
 ```json


### PR DESCRIPTION
Fix incorrect path in readme, the following configs are tried:

- `.../ovos_local_backend/ovos_backend.conf`
- `/etc/ovos_backend/ovos_backend.conf`
- `$HOME/.config/ovos_backend/web_cache.json`
- `$HOME/.config/ovos_backend/ovos_backend.conf`
- `/etc/xdg/ovos_backend/ovos_backend.conf`
- `/etc/xdg/xdg-gnome/ovos_backend/ovos_backend.conf`
- `$HOME/.ovos_backend/ovos_backend.conf`